### PR TITLE
chore(demo app): fix remaining webpack build errors

### DIFF
--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/OptionsContextBar.tsx
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/OptionsContextBar.tsx
@@ -44,7 +44,6 @@ const OptionsContextBar: React.FC = observer(() => {
         onOpenChange={(isOpen) => setNodeOptionsOpen(isOpen)}
         onSelect={() => {}}
         isOpen={nodeOptionsOpen}
-        placeholder="Node options"
         toggle={nodeOptionsToggle}
       >
         <SelectList>

--- a/packages/demo-app-ts/src/demos/topologyPackageDemo/listeners.ts
+++ b/packages/demo-app-ts/src/demos/topologyPackageDemo/listeners.ts
@@ -1,6 +1,6 @@
 import { Controller, EventListener, isNode, Node } from '@patternfly/react-topology';
 
-let positionTimer: NodeJS.Timer;
+let positionTimer: NodeJS.Timeout;
 
 export const graphPositionChangeListener: EventListener = ({ graph }): void => {
   const scale = graph.getScale();


### PR DESCRIPTION
The changes look good with just a couple cleanups needed due to some unsupported/deprecated props and types:

1) In `OptionsContextBar.tsx`, removed the `placeholder` prop from the Select component since it's now handled by the MenuToggle component below.

2) `NodeJS.Timer` type is deprecated, updated it to `NodeJS.Timeout`. 